### PR TITLE
Fix concurrent exception

### DIFF
--- a/src/main/java/pepjebs/mapatlases/lifecycle/MapAtlasesServerLifecycleEvents.java
+++ b/src/main/java/pepjebs/mapatlases/lifecycle/MapAtlasesServerLifecycleEvents.java
@@ -147,12 +147,7 @@ public class MapAtlasesServerLifecycleEvents {
         // Clean up disconnected players in server tick
         // since when using Disconnect event, the tick will sometimes
         // re-add the Player after they disconnect
-        // TODO: Fix concurrent exception here?
-        for (String playerName : playerToActiveMapId.keySet()) {
-            if (!seenPlayers.contains(playerName)) {
-                playerToActiveMapId.remove(playerName);
-            }
-        }
+        playerToActiveMapId.keySet().removeIf(playerName -> !seenPlayers.contains(playerName));
     }
 
     private static void updateMapDataForPlayer(


### PR DESCRIPTION
Fixes concurrent exception, crash doesn't appear anymore.
Do not remove HashMap keys while iterating over it the way it was done before.
Fixes #80, Fixes #83