### PR TITLE
feat: Recipe unlock advancement

### DIFF
--- a/src/main/resources/data/map_atlases/advancements/map_atlas.json
+++ b/src/main/resources/data/map_atlases/advancements/map_atlas.json
@@ -1,0 +1,25 @@
+{
+	"parent": "minecraft:recipes/root",
+	"criteria": {
+		"has_map": {
+			"conditions": {
+				"items": [
+					{
+						"items": ["minecraft:map"]
+					}
+				]
+			},
+			"trigger": "minecraft:inventory_changed"
+		},
+		"has_the_recipe": {
+			"conditions": {
+				"recipe": "map_atlases:dummy_crafting_atlas"
+			},
+			"trigger": "minecraft:recipe_unlocked"
+		}
+	},
+	"requirements": [["has_map", "has_the_recipe"]],
+	"rewards": {
+		"recipes": ["map_atlases:dummy_crafting_atlas"]
+	}
+}


### PR DESCRIPTION
This mod is aimed to be vanilla like, but there is one thing missing for it to be vanilla, and it is recipe unlock, currently if you play with just this mod, you will never learn the recipe for the atlas item unlike all recipes in vanilla.
This PR simply adds an advancement like all vanilla recipes has to unlock it, the criteria are to obtain empty map item. That way, after getting a blank map, you will see a toast with new recipes unlocked, and map atlas will appear in the Recipe Book. Only issue is that quick crafting doesn't work, I assume because of the dummy map item, but it will show the recipe and players will be able to insert items manually.