### PR TITLE
Allow removing ALL maps from the atlas.

### DIFF
--- a/src/main/java/pepjebs/mapatlases/item/MapAtlasItem.java
+++ b/src/main/java/pepjebs/mapatlases/item/MapAtlasItem.java
@@ -90,8 +90,13 @@ public class MapAtlasItem extends Item implements ExtendedScreenHandlerFactory {
 
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity player, Hand hand) {
-        openHandledAtlasScreen(world, player);
-        return TypedActionResult.consume(player.getStackInHand(hand));
+        ItemStack atlas = player.getStackInHand(hand);
+        if (MapAtlasesAccessUtils.hasAnyMap(atlas)){
+            openHandledAtlasScreen(world, player);
+            return TypedActionResult.consume(atlas);
+        }
+        else
+            return TypedActionResult.pass(atlas);
     }
 
     public void openHandledAtlasScreen(World world, PlayerEntity player) {
@@ -179,9 +184,14 @@ public class MapAtlasItem extends Item implements ExtendedScreenHandlerFactory {
     }
 
     public ActionResult useOnBlock(ItemUsageContext context) {
-        if (context.getPlayer() == null || context.getWorld() == null
-                || context.getStack() == null || context.getBlockPos() == null)
+        if (context.getPlayer() == null
+        || (context.getWorld() == null)
+        || (context.getStack() == null)
+        || (context.getBlockPos() == null)
+        || (!MapAtlasesAccessUtils.hasAnyMap(context.getStack()))
+        ) {
             return super.useOnBlock(context);
+        }
         BlockState blockState = context.getWorld().getBlockState(context.getBlockPos());
         if (blockState.isOf(Blocks.LECTERN)) {
             boolean didPut = LecternBlock.putBookIfAbsent(

--- a/src/main/java/pepjebs/mapatlases/item/MapAtlasItem.java
+++ b/src/main/java/pepjebs/mapatlases/item/MapAtlasItem.java
@@ -75,7 +75,7 @@ public class MapAtlasItem extends Item implements ExtendedScreenHandlerFactory {
             if (MapAtlasesMod.CONFIG == null || (MapAtlasesMod.CONFIG.requireEmptyMapsToExpand && MapAtlasesMod.CONFIG.enableEmptyMapEntryAndFill)) {
                 // If there's no maps & no empty maps, the atlas is "inactive", so display how many empty maps
                 // they *would* receive if they activated the atlas
-                if (mapSize + empties == 0 && MapAtlasesMod.CONFIG != null) {
+                if (stack.getNbt() == null && MapAtlasesMod.CONFIG != null) {
                     empties = MapAtlasesMod.CONFIG.pityActivationMapCount;
                 }
                 tooltip.add(Text.translatable("item.map_atlases.atlas.tooltip_2", empties)

--- a/src/main/java/pepjebs/mapatlases/recipe/MapAtlasesCutExistingRecipe.java
+++ b/src/main/java/pepjebs/mapatlases/recipe/MapAtlasesCutExistingRecipe.java
@@ -54,7 +54,7 @@ public class MapAtlasesCutExistingRecipe extends SpecialCraftingRecipe {
             }
         }
         if (atlas.getNbt() == null) return ItemStack.EMPTY;
-        if (MapAtlasesAccessUtils.getMapCountFromItemStack(atlas) > 1) {
+        if (MapAtlasesAccessUtils.hasAnyMap(atlas)) {
             List<Integer> mapIds = Arrays.stream(atlas.getNbt()
                     .getIntArray(MapAtlasItem.MAP_LIST_NBT)).boxed().collect(Collectors.toList());
             if (mapIds.size() > 0) {
@@ -77,7 +77,7 @@ public class MapAtlasesCutExistingRecipe extends SpecialCraftingRecipe {
                 cur.damage(1, Random.create(), null);
             } else if (cur.getItem() == MapAtlasesMod.MAP_ATLAS && cur.getNbt() != null) {
                 boolean didRemoveFilled = false;
-                if (MapAtlasesAccessUtils.getMapCountFromItemStack(cur) > 1) {
+                if (MapAtlasesAccessUtils.hasAnyMap(cur)) {
                     List<Integer> mapIds = Arrays.stream(cur.getNbt()
                             .getIntArray(MapAtlasItem.MAP_LIST_NBT)).boxed().collect(Collectors.toList());
                     if (mapIds.size() > 0) {

--- a/src/main/java/pepjebs/mapatlases/utils/MapAtlasesAccessUtils.java
+++ b/src/main/java/pepjebs/mapatlases/utils/MapAtlasesAccessUtils.java
@@ -171,6 +171,10 @@ public class MapAtlasesAccessUtils {
                 : new int[]{};
     }
 
+    public static boolean hasAnyMap(ItemStack atlas) {
+        return getMapIdsFromItemStack(atlas).length > 0;
+    }
+
     public static int getMapCountFromItemStack(ItemStack atlas) {
         return getMapIdsFromItemStack(atlas).length;
     }


### PR DESCRIPTION
Partial fix for #146.

Makes it so shears can be used to remove the last map in an atlas, making it empty.
Atlases emptied in this way do not receive "pity" maps when held. They do not display a minimap on the HUD, cannot be opened, and cannot be placed onto a lectern.