### PR TITLE
Fix icon zoom affecting all maps.

### DIFF
--- a/src/main/java/pepjebs/mapatlases/client/ui/MapAtlasesHUD.java
+++ b/src/main/java/pepjebs/mapatlases/client/ui/MapAtlasesHUD.java
@@ -143,6 +143,8 @@ public class MapAtlasesHUD extends DrawableHelper {
         RenderSystem.setShaderTexture(0, MAP_FOREGROUND);
         drawTexture(matrices,x,y,0,0,mapBgScaledSize,mapBgScaledSize,mapBgScaledSize,mapBgScaledSize);
 
+        MapAtlasesClient.setWorldMapZoomLevel(1);
+
         // Draw text data
         float textScaling = MapAtlasesMod.CONFIG.minimapCoordsAndBiomeScale;
         int textHeightOffset = mapBgScaledSize + 4;

--- a/src/main/java/pepjebs/mapatlases/screen/MapAtlasesAtlasOverviewScreen.java
+++ b/src/main/java/pepjebs/mapatlases/screen/MapAtlasesAtlasOverviewScreen.java
@@ -167,6 +167,8 @@ public class MapAtlasesAtlasOverviewScreen extends HandledScreen<ScreenHandler> 
             }
         }
 
+        MapAtlasesClient.setWorldMapZoomLevel(1);
+
         // Draw foreground
         RenderSystem.setShaderTexture(0, ATLAS_FOREGROUND);
         drawTexture(


### PR DESCRIPTION
After any of the mod's own map gui is drawn (both the mini-map and the world-map), the icon scale used in this gui will be applied to _all_ other maps in the world, (such as maps in item frames). This can causes them to have their icons unexpectedly and dramatically increase in size.

This is fixed by resetting the map zoom level to 1 immediately after drawing a map.

An example of repro:
- Get a filled map, put a banner on it, and hang it onto a wall. It should have normal icon sizes.
- Get an atlas, and put it into a lectern.
- Make sure the minimap is NOT visible.
- Read the atlas in the lectern, zoom out a bit, and close the lectern while zoomed out.
- The map in the item frame will have much bigger icons:
![2024-03-23_00 41 47](https://github.com/Pepperoni-Jabroni/MapAtlases/assets/39855800/a30e74d1-be1e-41a2-959c-4015c3801193)

