### PR TITLE
Fix incorrect scale tooltip

### DIFF
--- a/src/main/java/pepjebs/mapatlases/item/MapAtlasItem.java
+++ b/src/main/java/pepjebs/mapatlases/item/MapAtlasItem.java
@@ -81,10 +81,23 @@ public class MapAtlasItem extends Item implements ExtendedScreenHandlerFactory {
                 tooltip.add(Text.translatable("item.map_atlases.atlas.tooltip_2", empties)
                         .formatted(Formatting.GRAY));
             }
-            MapState mapState = world.getMapState(MapAtlasesClient.currentMapStateId);
-            if (mapState == null) return;
-            tooltip.add(Text.translatable("item.map_atlases.atlas.tooltip_3", 1 << mapState.scale)
-                    .formatted(Formatting.GRAY));
+
+            int[] mapIds = MapAtlasesAccessUtils.getMapIdsFromItemStack(stack);
+            MapState mapState = null;
+            // The client may not know about every map in the atlas if it has
+            // never been used, so we check them all until we find a valid one.
+            for (int i=0; i<mapIds.length; ++i){
+                mapState = world.getMapState("map_"+String.valueOf(mapIds[i]));
+                if (mapState != null) break;
+            }
+
+            if (mapState != null){
+                tooltip.add(Text.translatable("item.map_atlases.atlas.tooltip_3", 1 << mapState.scale)
+                        .formatted(Formatting.GRAY));
+            }
+            else if (mapIds.length > 0){
+                tooltip.add(Text.translatable("item.map_atlases.atlas.tooltip_unknown_scale").formatted(Formatting.GRAY));
+            }
         }
     }
 

--- a/src/main/resources/assets/map_atlases/lang/en_us.json
+++ b/src/main/resources/assets/map_atlases/lang/en_us.json
@@ -7,6 +7,7 @@
   "item.map_atlases.atlas.tooltip_3": "Scale: 1:%s",
   "item.map_atlases.atlas.tooltip_err": "Inactive",
   "item.map_atlases.atlas.tooltip_full": "Full!",
+  "item.map_atlases.atlas.tooltip_unknown_scale": "Unknown Scale",
   "key.map_atlases.open_minimap": "Open Minimap GUI",
   "item.map_atlases.dummy_filled_map": "Map",
   "item.map_atlases.dummy_filled_map.dummy": "Dummy",


### PR DESCRIPTION
Currently, the tooltip of atlases shows the scale of the atlas that has last been used, instead of figuring out the scale of the item itself. If the player's inventory contains multiple atlases of different scales, then all their tooltips will display the same scale value, which will be incorrect for most of them.

With this fix, there are still some cases where the client cannot figure out the scale of the maps inside an atlas. This should happen very rarely, and only for the same reasons that maps in chests sometimes show as "unknown map" instead of their map ID. In these cases, the atlas tooltip will show "Unknown Scale".