### PR TITLE
Fix bad map position in atlas.

### DIFF
--- a/src/main/java/pepjebs/mapatlases/screen/MapAtlasesAtlasOverviewScreen.java
+++ b/src/main/java/pepjebs/mapatlases/screen/MapAtlasesAtlasOverviewScreen.java
@@ -517,9 +517,10 @@ public class MapAtlasesAtlasOverviewScreen extends HandledScreen<ScreenHandler> 
      * @return The position of the map on the grid.
      */
     static private Vector2i BlockPosToMapTile(int x, int z, int mapSize){
+        int origin = (mapSize/2) - 64; //The blockpos at the center of the (0,0) map.
         Vector2i tile = new Vector2i();
-        tile.x = x / mapSize;
-        tile.y = z / mapSize;
+        tile.x = (x-origin) / mapSize;
+        tile.y = (z-origin) / mapSize;
         return tile;
     }
 


### PR DESCRIPTION
Fixes a bug that I introduced with my optimization, that causes some maps to appear at the world origin.

I was naively using coordinates from the `MapState`, but it turns out the client is not supposed to know them. (Singleplayer clients still get them right quite often for some reason.)
This time I'm getting them from the `idsToCenters` list, as it should have been.